### PR TITLE
Change invalid key status to be 400

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ router.get("/:key", async ctx => {
   const isValidKey = !validateKey(key);
 
   if (!isValidKey) {
-    ctx.status = 401;
+    ctx.status = 400;
     ctx.body = {
       status: "error",
       message: `Invalid key ${key}.`


### PR DESCRIPTION
401 - unauthorized, is:
The request has not been applied because it lacks valid
authentication credentials for the target resource.

You probably want 400 - bad request:
The server cannot or will not process the request due to something
that is perceived to be a client error (e.g., malformed request
syntax, invalid request message framing, or deceptive request
routing).